### PR TITLE
Add TracerResolver support to return a default logging tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ span.log(MapMaker.fields(LogLevel.FIELD_NAME, LogLevel.WARN, "k0", "v0", "ex", n
 
 * Add dependency (format depends of your build tool)
 ```
-"io.opentracing.contrib" % "java-span-reporter" % "${span-reporter.version}"
+"io.opentracing.contrib" % "span-reporter" % "${span-reporter.version}"
 ```
 * Instantiate the TracerR (For using DI, you can take inspiration from [Guice samples](./src/test/java/io/opentracing/contrib/di)
 ):
@@ -81,3 +81,14 @@ tracer = new TracerR(tracer, new CompositeReporter(
     new DropwizardMetricsReporter(...)
 ));
 ```
+
+## Use as a Logging Tracer
+
+To use the java span reporter as a simple Logging Tracer via the
+[TracerResolver](https://github.com/opentracing-contrib/java-tracerresolver), just add the following dependency
+(format depends of your build tool):
+
+```
+"io.opentracing.contrib" % "span-reporter-resolver" % "${span-reporter.version}"
+```
+

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 
     <modules>
         <module>span-reporter</module>
+        <module>span-reporter-resolver</module>
         <module>span-reporter-slf4j</module>
         <module>span-reporter-examples</module>
     </modules>
@@ -51,6 +52,7 @@
         <build.java.version>1.8</build.java.version>
 
         <opentracing-api.version>0.20.10</opentracing-api.version>
+        <opentracing-tracerresolver.version>0.1.0</opentracing-tracerresolver.version>
         <junit.version>4.12</junit.version>
 
         <maven-plugin.version>0.3.3</maven-plugin.version>
@@ -109,6 +111,11 @@
                 <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-mock</artifactId>
                 <version>${opentracing-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-tracerresolver</artifactId>
+                <version>${opentracing-tracerresolver.version}</version>
             </dependency>
             <!-- Test -->
             <dependency>

--- a/span-reporter-resolver/pom.xml
+++ b/span-reporter-resolver/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>span-reporter-parent</artifactId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>span-reporter-resolver</artifactId>
+    <name>SpanReporter Resolver</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-noop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-tracerresolver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>span-reporter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>span-reporter-slf4j</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/span-reporter-resolver/src/main/java/io/opentracing/contrib/reporter/resolver/SpanReporterResolver.java
+++ b/span-reporter-resolver/src/main/java/io/opentracing/contrib/reporter/resolver/SpanReporterResolver.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.reporter.resolver;
+
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.NoopTracerFactory;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.reporter.TracerR;
+import io.opentracing.contrib.reporter.slf4j.Slf4jReporter;
+import io.opentracing.contrib.tracerresolver.TracerResolver;
+
+/**
+ * This class provides a {@link TracerResolver} to return a span reporter as
+ * a {@link Tracer}.
+ */
+public class SpanReporterResolver extends TracerResolver {
+
+    @Override
+    protected Tracer resolve() {
+        return new TracerR(NoopTracerFactory.create(), new Slf4jReporter(LoggerFactory.getLogger("tracer"), true));
+    }
+}

--- a/span-reporter-resolver/src/main/resources/META-INF/services/io.opentracing.contrib.tracerresolver.TracerResolver
+++ b/span-reporter-resolver/src/main/resources/META-INF/services/io.opentracing.contrib.tracerresolver.TracerResolver
@@ -1,0 +1,1 @@
+io.opentracing.contrib.reporter.resolver.SpanReporterResolver

--- a/span-reporter-resolver/src/test/java/io/opentracing/contrib/reporter/resolver/SpanReporterResolverTest.java
+++ b/span-reporter-resolver/src/test/java/io/opentracing/contrib/reporter/resolver/SpanReporterResolverTest.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.reporter.resolver;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.opentracing.contrib.reporter.TracerR;
+import io.opentracing.contrib.tracerresolver.TracerResolver;
+
+public class SpanReporterResolverTest {
+
+    @Test
+    public void testResolve() {
+        assertTrue(TracerResolver.resolveTracer() instanceof TracerR);
+    }
+
+}


### PR DESCRIPTION
Interest from microprofile.io in a default Logging Tracer: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/microprofile/YxKba36lye4/iVmu6WOoAwAJ (bullet point 2) that can be easily switched to other Tracer implementations without code change - hence this PR to provide a TracerResolver.
