### PR TITLE
span-reporter span id generation is very slow. #18

### DIFF
--- a/span-reporter/src/main/java/io/opentracing/contrib/reporter/TracerR.java
+++ b/span-reporter/src/main/java/io/opentracing/contrib/reporter/TracerR.java
@@ -66,4 +66,9 @@ public class TracerR implements Tracer {
         this.wrapped.close();
     }
 
+    @Override
+    public String toString() {
+        return "SpanReporterTracer{" + wrapped + '}';
+    }
+
 }


### PR DESCRIPTION
This is the PR for issue #18 
Span-reporter should have an option to use the tracing implementation's span id instead of generating its own. 
Span-reporter method SpanBuilderR.findSpanId calls context.baggageItems() twice. 


